### PR TITLE
Switched from flashing to booting TWRP

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ If you want to use the tool for a non-supported smartphone, the fastest way is t
 
 #### Content of a config file
 
-A config file consists of two parts. The first part are some metadata about the device and the second parts are the steps to unlock the bootloader, flash a recovery and install the ROMs.
+A config file consists of two parts. The first part are some metadata about the device and the second parts are the steps to unlock the bootloader, boot a recovery and install the ROMs.
 
 ##### How to write Metadata
 Every config file should have metadata with the following fields:
@@ -213,7 +213,7 @@ Every step in the config file corresponds to one view in the application. These 
   - `call_button_with_input`: Display the content text, an input field and a button that runs a given command. The inputtext, can be used in the command by using the `<inputtext>` placeholder in the command field. After the command is run, a confirm button is displayed to allow the user to move to the next step.
   - `link_button_with_confirm`: Display a button that opens a browser with a given link, confirm afterwards. Link is given in `link`.
 - `content`: str; The content text displayed alongside the action of the step. Used to inform the user about whats going on.
-- `command`: [ONLY for call_button* steps] str; The command to run. One of `adb_reboot`, `adb_reboot_bootloader`, `adb_reboot_download`, `adb_sideload`, `adb_twrp_wipe_and_install`, `adb_twrp_copy_partitions`, `fastboot_flash_recovery`, `fastboot_unlock_with_code`, `fastboot_unlock`, `fastboot_oem_unlock`, `fastboot_get_unlock_data`, `fastboot_reboot`, `heimdall_flash_recovery`.
+- `command`: [ONLY for call_button* steps] str; The command to run. One of `adb_reboot`, `adb_reboot_bootloader`, `adb_reboot_download`, `adb_sideload`, `adb_twrp_wipe_and_install`, `adb_twrp_copy_partitions`, `fastboot_boot_recovery`, `fastboot_unlock_with_code`, `fastboot_unlock`, `fastboot_oem_unlock`, `fastboot_get_unlock_data`, `fastboot_reboot`, `heimdall_flash_recovery`.
 - `img`: [OPTIONAL] Display an image on the left pane of the step view. Images are loaded from `openandroidinstaller/assets/imgs/`.
 - `allow_skip`: [OPTIONAL] boolean; If a skip button should be displayed to allow skipping this step. Can be useful when the bootloader is already unlocked.
 - `link`: [OPTIONAL] Link to use for the link button if type is `link_button_with_confirm`.

--- a/openandroidinstaller/app_state.py
+++ b/openandroidinstaller/app_state.py
@@ -67,5 +67,5 @@ class AppState:
         self.config = _load_config(device_code, self.config_path)
         if self.config:
             self.steps = copy.deepcopy(self.config.unlock_bootloader) + copy.deepcopy(
-                self.config.flash_recovery
+                self.config.boot_recovery
             )

--- a/openandroidinstaller/assets/configs/FP2.yaml
+++ b/openandroidinstaller/assets/configs/FP2.yaml
@@ -4,17 +4,17 @@ metadata:
   devicecode: FP2
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: confirm_button 
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating, 
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating, 
         adapting and repairing of the operating system.
     - type: call_button
       content: Once the device is fully booted, you need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery
     - type: confirm_button 
       content: >
         Now reboot into recovery to verify the installation. Do not reboot into the existing OS, since it will overwrite the recovery you just installed!

--- a/openandroidinstaller/assets/configs/FP3.yaml
+++ b/openandroidinstaller/assets/configs/FP3.yaml
@@ -29,17 +29,17 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: confirm_button 
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating, 
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating, 
         adapting and repairing of the operating system.
     - type: call_button
       content: Turn on your device. Once the device is fully booted, you need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
       content: Once the device is in fastboot mode, flash the custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      command: fastboot_boot_recovery
     - type: confirm_button 
       content: >
         Now reboot into recovery to verify the installation. Do not reboot into the existing OS, since it will overwrite the recovery you just installed!

--- a/openandroidinstaller/assets/configs/FP4.yaml
+++ b/openandroidinstaller/assets/configs/FP4.yaml
@@ -29,17 +29,17 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: confirm_button 
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating, 
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating, 
         adapting and repairing of the operating system.
     - type: call_button
       content: Turn on your device. Once the device is fully booted, you need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
       content: Once the device is in fastboot mode, flash the custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      command: fastboot_boot_recovery
     - type: confirm_button 
       content: >
         Now reboot into recovery to verify the installation. Do not reboot into the existing OS, since it will overwrite the recovery you just installed!

--- a/openandroidinstaller/assets/configs/a3y17lte.yaml
+++ b/openandroidinstaller/assets/configs/a3y17lte.yaml
@@ -4,7 +4,7 @@ metadata:
   devicecode: a3y17lte
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         As a first step, you need to boot into the bootloader. A bootloader is the piece of software,
@@ -13,7 +13,7 @@ steps:
       command: adb_reboot_download
     - type: call_button
       content: >
-        In this step, you need to flash a custom recovery on your device.
+        In this step, you need to boot a custom recovery on your device.
         Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button

--- a/openandroidinstaller/assets/configs/a5xelte.yaml
+++ b/openandroidinstaller/assets/configs/a5xelte.yaml
@@ -4,7 +4,7 @@ metadata:
   devicecode: a5xelte
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         As a first step, you need to boot into the bootloader. A bootloader is the piece of software, 
@@ -12,7 +12,7 @@ steps:
         Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons.png

--- a/openandroidinstaller/assets/configs/a72q.yaml
+++ b/openandroidinstaller/assets/configs/a72q.yaml
@@ -4,7 +4,7 @@ metadata:
   devicecode: a72q 
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         As a first step, you need to boot into the bootloader. A bootloader is the piece of software, 
@@ -12,7 +12,7 @@ steps:
         Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons.png

--- a/openandroidinstaller/assets/configs/a7xelte.yaml
+++ b/openandroidinstaller/assets/configs/a7xelte.yaml
@@ -4,7 +4,7 @@ metadata:
   devicecode: a7xelte
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         As a first step, you need to boot into the bootloader. A bootloader is the piece of software, 
@@ -12,7 +12,7 @@ steps:
         Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons.png

--- a/openandroidinstaller/assets/configs/akari.yaml
+++ b/openandroidinstaller/assets/configs/akari.yaml
@@ -33,15 +33,15 @@ steps:
         Press the button to reboot. Since the device resets completely, you will need to re-enable USB debugging to continue. 
         Connect your device to your PC via USB. Then confirm here to continue.
       command: fastboot_reboot
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
       command: fastboot_flash_boot
     - type: call_button
       command: adb_twrp_copy_partitions

--- a/openandroidinstaller/assets/configs/akatsuki.yaml
+++ b/openandroidinstaller/assets/configs/akatsuki.yaml
@@ -33,15 +33,15 @@ steps:
         Press the button to reboot. Since the device resets completely, you will need to re-enable USB debugging to continue. 
         Connect your device to your PC via USB. Then confirm here to continue.
       command: fastboot_reboot
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
       command: fastboot_flash_boot
     - type: call_button
       command: adb_twrp_copy_partitions

--- a/openandroidinstaller/assets/configs/avicii.yaml
+++ b/openandroidinstaller/assets/configs/avicii.yaml
@@ -24,22 +24,22 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery
     - type: call_button
       command: adb_twrp_copy_partitions
       content: >
         In some cases, the inactive slot can be unpopulated or contain much older firmware than the active slot, leading to various issues including a potential hard-brick.
         We can ensure none of that will happen by copying the contents of the active slot to the inactive slot. Press 'confirm and run' to to this. Once you are in the bootloader again, continue.
     - type: call_button
-      command: fastboot_flash_recovery
+      command: fastboot_boot_recovery
       content: >
         Now we need to boot into recovery again. Press run and when you see the TWRP screen you can continue.

--- a/openandroidinstaller/assets/configs/barbet.yaml
+++ b/openandroidinstaller/assets/configs/barbet.yaml
@@ -29,10 +29,10 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: confirm_button 
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
     - type: call_button
       content: Once the device is fully booted, you need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
@@ -40,5 +40,5 @@ steps:
     - type: confirm_button
       content: Select 'Restart bootloader' on your smartphone screen. Then confirm to continue.
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery

--- a/openandroidinstaller/assets/configs/beyond0lte.yaml
+++ b/openandroidinstaller/assets/configs/beyond0lte.yaml
@@ -21,14 +21,14 @@ steps:
       content: >
         The bootloader is now unlocked. Go through Android Setup skipping everything you can, then connect the device to a Wi-Fi network.
         Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         Now plug the USB-cable to your device. As a first step, you need to boot into download mode. Your device should be turned on. 
         Then press 'Confirm and run' to reboot into download mode. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons-bixby.png

--- a/openandroidinstaller/assets/configs/beyond1lte.yaml
+++ b/openandroidinstaller/assets/configs/beyond1lte.yaml
@@ -21,14 +21,14 @@ steps:
       content: >
         The bootloader is now unlocked. Go through Android Setup skipping everything you can, then connect the device to a Wi-Fi network.
         Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         Now plug the USB-cable to your device. As a first step, you need to boot into download mode. Your device should be turned on. 
         Then press 'Confirm and run' to reboot into download mode. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons-bixby.png

--- a/openandroidinstaller/assets/configs/beyond2lte.yaml
+++ b/openandroidinstaller/assets/configs/beyond2lte.yaml
@@ -21,14 +21,14 @@ steps:
       content: >
         The bootloader is now unlocked. Go through Android Setup skipping everything you can, then connect the device to a Wi-Fi network.
         Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         Now plug the USB-cable to your device. As a first step, you need to boot into download mode. Your device should be turned on. 
         Then press 'Confirm and run' to reboot into download mode. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons-bixby.png

--- a/openandroidinstaller/assets/configs/blueline.yaml
+++ b/openandroidinstaller/assets/configs/blueline.yaml
@@ -24,14 +24,14 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once your phone screen looks like the picture on the left, continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once your phone screen looks like the picture on the left, continue.
+      command: fastboot_boot_recovery
       img: twrp-start.jpeg

--- a/openandroidinstaller/assets/configs/bonito.yaml
+++ b/openandroidinstaller/assets/configs/bonito.yaml
@@ -24,14 +24,14 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once your phone screen looks like the picture on the left, continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once your phone screen looks like the picture on the left, continue.
+      command: fastboot_boot_recovery
       img: twrp-start.jpeg

--- a/openandroidinstaller/assets/configs/cedric.yaml
+++ b/openandroidinstaller/assets/configs/cedric.yaml
@@ -34,13 +34,13 @@ steps:
         Press the button to reboot. Since the device resets completely, you will need to re-enable USB debugging to continue. 
         Connect your device to your PC via USB. Then confirm here to continue.
       command: fastboot_reboot
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery

--- a/openandroidinstaller/assets/configs/cheeseburger.yaml
+++ b/openandroidinstaller/assets/configs/cheeseburger.yaml
@@ -23,13 +23,13 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery

--- a/openandroidinstaller/assets/configs/coral.yaml
+++ b/openandroidinstaller/assets/configs/coral.yaml
@@ -29,10 +29,10 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: confirm_button 
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
     - type: call_button
       content: Once the device is fully booted, you need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
@@ -40,5 +40,5 @@ steps:
     - type: confirm_button
       content: Select 'Restart bootloader' on your smartphone screen. Then confirm to continue.
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery

--- a/openandroidinstaller/assets/configs/crosshatch.yaml
+++ b/openandroidinstaller/assets/configs/crosshatch.yaml
@@ -24,14 +24,14 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once your phone screen looks like the picture on the left, continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once your phone screen looks like the picture on the left, continue.
+      command: fastboot_boot_recovery
       img: twrp-start.jpeg

--- a/openandroidinstaller/assets/configs/crownlte.yaml
+++ b/openandroidinstaller/assets/configs/crownlte.yaml
@@ -6,7 +6,7 @@ requirements:
   android: 10
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         As a first step, you need to boot into the bootloader. A bootloader is the piece of software, 
@@ -14,7 +14,7 @@ steps:
         Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons-bixby.png

--- a/openandroidinstaller/assets/configs/d1.yaml
+++ b/openandroidinstaller/assets/configs/d1.yaml
@@ -21,14 +21,14 @@ steps:
       content: >
         The bootloader is now unlocked. Go through Android Setup skipping everything you can, then connect the device to a Wi-Fi network.
         Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         Now plug the USB-cable to your device. As a first step, you need to boot into download mode. Your device should be turned on. 
         Then press 'Confirm and run' to reboot into download mode. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons-bixby.png

--- a/openandroidinstaller/assets/configs/d2s.yaml
+++ b/openandroidinstaller/assets/configs/d2s.yaml
@@ -21,14 +21,14 @@ steps:
       content: >
         The bootloader is now unlocked. Go through Android Setup skipping everything you can, then connect the device to a Wi-Fi network.
         Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         Now plug the USB-cable to your device. As a first step, you need to boot into download mode. Your device should be turned on. 
         Then press 'Confirm and run' to reboot into download mode. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons-bixby.png

--- a/openandroidinstaller/assets/configs/dre.yaml
+++ b/openandroidinstaller/assets/configs/dre.yaml
@@ -24,22 +24,22 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery
     - type: call_button
       command: adb_twrp_copy_partitions
       content: >
         In some cases, the inactive slot can be unpopulated or contain much older firmware than the active slot, leading to various issues including a potential hard-brick.
         We can ensure none of that will happen by copying the contents of the active slot to the inactive slot. Press 'confirm and run' to to this. Once you are in the bootloader again, continue.
     - type: call_button
-      command: fastboot_flash_recovery
+      command: fastboot_boot_recovery
       content: >
         Now we need to boot into recovery again. Press run and when you see the TWRP screen you can continue.

--- a/openandroidinstaller/assets/configs/dumpling.yaml
+++ b/openandroidinstaller/assets/configs/dumpling.yaml
@@ -23,13 +23,13 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery

--- a/openandroidinstaller/assets/configs/enchilada.yaml
+++ b/openandroidinstaller/assets/configs/enchilada.yaml
@@ -24,22 +24,22 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery
     - type: call_button
       command: adb_twrp_copy_partitions
       content: >
         In some cases, the inactive slot can be unpopulated or contain much older firmware than the active slot, leading to various issues including a potential hard-brick.
         We can ensure none of that will happen by copying the contents of the active slot to the inactive slot. Press 'confirm and run' to to this. Once you are in the bootloader again, continue.
     - type: call_button
-      command: fastboot_flash_recovery
+      command: fastboot_boot_recovery
       content: >
         Now we need to boot into recovery again. Press run and when you see the TWRP screen you can continue.

--- a/openandroidinstaller/assets/configs/evert.yaml
+++ b/openandroidinstaller/assets/configs/evert.yaml
@@ -34,22 +34,22 @@ steps:
         Press the button to reboot. Since the device resets completely, you will need to re-enable USB debugging to continue. 
         Connect your device to your PC via USB. Then confirm here to continue.
       command: fastboot_reboot
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery
     - type: call_button
       command: adb_twrp_copy_partitions
       content: >
         In some cases, the inactive slot can be unpopulated or contain much older firmware than the active slot, leading to various issues including a potential hard-brick.
         We can ensure none of that will happen by copying the contents of the active slot to the inactive slot. Press 'confirm and run' to to this. Once you are in the bootloader again, continue.
     - type: call_button
-      command: fastboot_flash_recovery
+      command: fastboot_boot_recovery
       content: >
         Now we need to boot into recovery again. Press run and when you see the TWRP screen you can continue.

--- a/openandroidinstaller/assets/configs/fajita.yaml
+++ b/openandroidinstaller/assets/configs/fajita.yaml
@@ -24,22 +24,22 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery
     - type: call_button
       command: adb_twrp_copy_partitions
       content: >
         In some cases, the inactive slot can be unpopulated or contain much older firmware than the active slot, leading to various issues including a potential hard-brick.
         We can ensure none of that will happen by copying the contents of the active slot to the inactive slot. Press 'confirm and run' to to this. Once you are in the bootloader again, continue.
     - type: call_button
-      command: fastboot_flash_recovery
+      command: fastboot_boot_recovery
       content: >
         Now we need to boot into recovery again. Press run and when you see the TWRP screen you can continue.

--- a/openandroidinstaller/assets/configs/flame.yaml
+++ b/openandroidinstaller/assets/configs/flame.yaml
@@ -29,10 +29,10 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: confirm_button 
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
     - type: call_button
       content: Once the device is fully booted, you need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
@@ -40,5 +40,5 @@ steps:
     - type: confirm_button
       content: Select 'Restart bootloader' on your smartphone screen. Then confirm to continue.
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery

--- a/openandroidinstaller/assets/configs/greatlte.yaml
+++ b/openandroidinstaller/assets/configs/greatlte.yaml
@@ -4,7 +4,7 @@ metadata:
   devicecode: greatlte 
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         As a first step, you need to boot into the bootloader. A bootloader is the piece of software, 
@@ -12,7 +12,7 @@ steps:
         Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons-bixby.png

--- a/openandroidinstaller/assets/configs/griffin.yaml
+++ b/openandroidinstaller/assets/configs/griffin.yaml
@@ -34,13 +34,13 @@ steps:
         Press the button to reboot. Since the device resets completely, you will need to re-enable USB debugging to continue.
         Connect your device to your PC via USB. Then confirm here to continue.
       command: fastboot_reboot
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery

--- a/openandroidinstaller/assets/configs/guacamole.yaml
+++ b/openandroidinstaller/assets/configs/guacamole.yaml
@@ -24,13 +24,13 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery

--- a/openandroidinstaller/assets/configs/guacamoleb.yaml
+++ b/openandroidinstaller/assets/configs/guacamoleb.yaml
@@ -24,13 +24,13 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery

--- a/openandroidinstaller/assets/configs/hero2lte.yaml
+++ b/openandroidinstaller/assets/configs/hero2lte.yaml
@@ -4,7 +4,7 @@ metadata:
   devicecode: hero2lte 
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         As a first step, you need to boot into the bootloader. A bootloader is the piece of software, 
@@ -12,7 +12,7 @@ steps:
         Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons.png

--- a/openandroidinstaller/assets/configs/herolte.yaml
+++ b/openandroidinstaller/assets/configs/herolte.yaml
@@ -4,7 +4,7 @@ metadata:
   devicecode: herolte 
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         As a first step, you need to boot into the bootloader. A bootloader is the piece of software, 
@@ -12,7 +12,7 @@ steps:
         Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons.png

--- a/openandroidinstaller/assets/configs/heroltexx.yaml
+++ b/openandroidinstaller/assets/configs/heroltexx.yaml
@@ -4,7 +4,7 @@ metadata:
   devicecode: herolte 
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         As a first step, you need to boot into the bootloader. A bootloader is the piece of software, 
@@ -12,7 +12,7 @@ steps:
         Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons.png

--- a/openandroidinstaller/assets/configs/hltetmo.yaml
+++ b/openandroidinstaller/assets/configs/hltetmo.yaml
@@ -4,7 +4,7 @@ metadata:
   devicecode: hltetmo 
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         As a first step, you need to boot into the bootloader. A bootloader is the piece of software,
@@ -13,7 +13,7 @@ steps:
       command: adb_reboot_download
     - type: call_button
       content: >
-        In this step, you need to flash a custom recovery on your device.
+        In this step, you need to boot a custom recovery on your device.
         Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button

--- a/openandroidinstaller/assets/configs/hotdog.yaml
+++ b/openandroidinstaller/assets/configs/hotdog.yaml
@@ -24,13 +24,13 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery

--- a/openandroidinstaller/assets/configs/hotdogb.yaml
+++ b/openandroidinstaller/assets/configs/hotdogb.yaml
@@ -24,13 +24,13 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery

--- a/openandroidinstaller/assets/configs/j7elte.yaml
+++ b/openandroidinstaller/assets/configs/j7elte.yaml
@@ -4,7 +4,7 @@ metadata:
   devicecode: j7elte 
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         As a first step, you need to boot into the bootloader. A bootloader is the piece of software, 
@@ -12,7 +12,7 @@ steps:
         Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons.png

--- a/openandroidinstaller/assets/configs/kiev.yaml
+++ b/openandroidinstaller/assets/configs/kiev.yaml
@@ -34,22 +34,22 @@ steps:
         Press the button to reboot. Since the device resets completely, you will need to re-enable USB debugging to continue. 
         Connect your device to your PC via USB. Then confirm here to continue.
       command: fastboot_reboot
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery
     - type: call_button
       command: adb_twrp_copy_partitions
       content: >
         In some cases, the inactive slot can be unpopulated or contain much older firmware than the active slot, leading to various issues including a potential hard-brick.
         We can ensure none of that will happen by copying the contents of the active slot to the inactive slot. Press 'confirm and run' to to this. Once you are in the bootloader again, continue.
     - type: call_button
-      command: fastboot_flash_recovery
+      command: fastboot_boot_recovery
       content: >
         Now we need to boot into recovery again. Press run and when you see the TWRP screen you can continue.

--- a/openandroidinstaller/assets/configs/kirin.yaml
+++ b/openandroidinstaller/assets/configs/kirin.yaml
@@ -31,15 +31,15 @@ steps:
         Press the button to reboot. Since the device resets completely, you will need to re-enable USB debugging to continue. 
         Connect your device to your PC via USB. Then confirm here to continue.
       command: fastboot_reboot
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
       command: fastboot_flash_boot
     - type: call_button
       command: adb_twrp_copy_partitions

--- a/openandroidinstaller/assets/configs/mermaid.yaml
+++ b/openandroidinstaller/assets/configs/mermaid.yaml
@@ -31,15 +31,15 @@ steps:
         Press the button to reboot. Since the device resets completely, you will need to re-enable USB debugging to continue. 
         Connect your device to your PC via USB. Then confirm here to continue.
       command: fastboot_reboot
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
       command: fastboot_flash_boot
     - type: call_button
       command: adb_twrp_copy_partitions

--- a/openandroidinstaller/assets/configs/nairo.yaml
+++ b/openandroidinstaller/assets/configs/nairo.yaml
@@ -34,22 +34,22 @@ steps:
         Press the button to reboot. Since the device resets completely, you will need to re-enable USB debugging to continue. 
         Connect your device to your PC via USB. Then confirm here to continue.
       command: fastboot_reboot
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery
     - type: call_button
       command: adb_twrp_copy_partitions
       content: >
         In some cases, the inactive slot can be unpopulated or contain much older firmware than the active slot, leading to various issues including a potential hard-brick.
         We can ensure none of that will happen by copying the contents of the active slot to the inactive slot. Press 'confirm and run' to to this. Once you are in the bootloader again, continue.
     - type: call_button
-      command: fastboot_flash_recovery
+      command: fastboot_boot_recovery
       content: >
         Now we need to boot into recovery again. Press run and when you see the TWRP screen you can continue.

--- a/openandroidinstaller/assets/configs/ocean.yaml
+++ b/openandroidinstaller/assets/configs/ocean.yaml
@@ -34,22 +34,22 @@ steps:
         Press the button to reboot. Since the device resets completely, you will need to re-enable USB debugging to continue. 
         Connect your device to your PC via USB. Then confirm here to continue.
       command: fastboot_reboot
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery
     - type: call_button
       command: adb_twrp_copy_partitions
       content: >
         In some cases, the inactive slot can be unpopulated or contain much older firmware than the active slot, leading to various issues including a potential hard-brick.
         We can ensure none of that will happen by copying the contents of the active slot to the inactive slot. Press 'confirm and run' to to this. Once you are in the bootloader again, continue.
     - type: call_button
-      command: fastboot_flash_recovery
+      command: fastboot_boot_recovery
       content: >
         Now we need to boot into recovery again. Press run and when you see the TWRP screen you can continue.

--- a/openandroidinstaller/assets/configs/pioneer.yaml
+++ b/openandroidinstaller/assets/configs/pioneer.yaml
@@ -33,15 +33,15 @@ steps:
         Press the button to reboot. Since the device resets completely, you will need to re-enable USB debugging to continue. 
         Connect your device to your PC via USB. Then confirm here to continue.
       command: fastboot_reboot
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
       command: fastboot_flash_boot
     - type: call_button
       command: adb_twrp_copy_partitions

--- a/openandroidinstaller/assets/configs/racer.yaml
+++ b/openandroidinstaller/assets/configs/racer.yaml
@@ -34,22 +34,22 @@ steps:
         Press the button to reboot. Since the device resets completely, you will need to re-enable USB debugging to continue. 
         Connect your device to your PC via USB. Then confirm here to continue.
       command: fastboot_reboot
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery
     - type: call_button
       command: adb_twrp_copy_partitions
       content: >
         In some cases, the inactive slot can be unpopulated or contain much older firmware than the active slot, leading to various issues including a potential hard-brick.
         We can ensure none of that will happen by copying the contents of the active slot to the inactive slot. Press 'confirm and run' to to this. Once you are in the bootloader again, continue.
     - type: call_button
-      command: fastboot_flash_recovery
+      command: fastboot_boot_recovery
       content: >
         Now we need to boot into recovery again. Press run and when you see the TWRP screen you can continue.

--- a/openandroidinstaller/assets/configs/redfin.yaml
+++ b/openandroidinstaller/assets/configs/redfin.yaml
@@ -29,10 +29,10 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: confirm_button 
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
     - type: call_button
       content: Once the device is fully booted, you need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
@@ -40,5 +40,5 @@ steps:
     - type: confirm_button
       content: Select 'Restart bootloader' on your smartphone screen. Then confirm to continue.
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery

--- a/openandroidinstaller/assets/configs/s3ve3g.yaml
+++ b/openandroidinstaller/assets/configs/s3ve3g.yaml
@@ -4,7 +4,7 @@ metadata:
   devicecode: s3ve3g 
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: confirm_button
       content: >
         There are two possible hardware configurations of this phone regardless of model number. Some phones were released with a Sony IMX 175 rear camera sensor, while others with a Samsung s5k4h5yb rear camera sensor. As such, we’ve separated this devices builds into two separate builds. The procedure to distinguish which to use is as follows:
@@ -26,7 +26,7 @@ steps:
       command: adb_reboot_download
     - type: call_button
       content: >
-        In this step, you need to flash a custom recovery on your device.
+        In this step, you need to boot a custom recovery on your device.
         Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button

--- a/openandroidinstaller/assets/configs/sargo.yaml
+++ b/openandroidinstaller/assets/configs/sargo.yaml
@@ -24,14 +24,14 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once your phone screen looks like the picture on the left, continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once your phone screen looks like the picture on the left, continue.
+      command: fastboot_boot_recovery
       img: twrp-start.jpeg

--- a/openandroidinstaller/assets/configs/starlte.yaml
+++ b/openandroidinstaller/assets/configs/starlte.yaml
@@ -6,7 +6,7 @@ requirements:
   android: 10
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         As a first step, you need to boot into the bootloader. A bootloader is the piece of software, 
@@ -14,7 +14,7 @@ steps:
         Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       content: >

--- a/openandroidinstaller/assets/configs/sunfish.yaml
+++ b/openandroidinstaller/assets/configs/sunfish.yaml
@@ -29,10 +29,10 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: confirm_button 
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
     - type: call_button
       content: Once the device is fully booted, you need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
@@ -40,5 +40,5 @@ steps:
     - type: confirm_button
       content: Select 'Restart bootloader' on your smartphone screen. Then confirm to continue.
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_boot_recovery

--- a/openandroidinstaller/assets/configs/taimen.yaml
+++ b/openandroidinstaller/assets/configs/taimen.yaml
@@ -24,14 +24,14 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once your phone screen looks like the picture on the left, continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once your phone screen looks like the picture on the left, continue.
+      command: fastboot_boot_recovery
       img: twrp-start.jpeg

--- a/openandroidinstaller/assets/configs/walleye.yaml
+++ b/openandroidinstaller/assets/configs/walleye.yaml
@@ -24,14 +24,14 @@ steps:
       command: fastboot_reboot
     - type: confirm_button
       content: The bootloader is now unlocked. Since the device resets completely, you will need to re-enable Developer Options and USB debugging to continue.
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
-        Now you need to flash a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
         adapting and repairing of the operating system.
         Make sure your device is turned on. You need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Flash a custom recovery (temporarily) by pressing 'Confirm and run'. Once your phone screen looks like the picture on the left, continue.
-      command: fastboot_flash_recovery
+      content: Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once your phone screen looks like the picture on the left, continue.
+      command: fastboot_boot_recovery
       img: twrp-start.jpeg

--- a/openandroidinstaller/assets/configs/yuga.yaml
+++ b/openandroidinstaller/assets/configs/yuga.yaml
@@ -31,10 +31,10 @@ steps:
         Press the button to reboot. Since the device resets completely, you will need to re-enable USB debugging to continue. 
         Connect your device to your PC via USB. Then confirm here to continue.
       command: fastboot_reboot
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: Now you have to reboot into bootloader again. With your phone turned on, press the button to do so and continue once it is done.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Next, you need to flash a custom recovery image. Press the button to flash the selected image. Then continue.
+      content: Next, you need to boot a custom recovery image. Press the button to flash the selected image. Then continue.
       command: fastboot_flash_boot

--- a/openandroidinstaller/assets/configs/z3.yaml
+++ b/openandroidinstaller/assets/configs/z3.yaml
@@ -33,10 +33,10 @@ steps:
         Press the button to reboot. Since the device resets completely, you will need to re-enable USB debugging to continue. 
         Connect your device to your PC via USB. Then confirm here to continue.
       command: fastboot_reboot
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: Now you have to reboot into bootloader again. With your phone turned on, press the button to do so and continue once it is done.
       command: adb_reboot_bootloader
     - type: call_button
-      content: Next, you need to flash a custom recovery image. Press the button to flash the selected image. Then continue.
+      content: Next, you need to boot a custom recovery image. Press the button to flash the selected image. Then continue.
       command: fastboot_flash_boot

--- a/openandroidinstaller/assets/configs/zerofltexx.yaml
+++ b/openandroidinstaller/assets/configs/zerofltexx.yaml
@@ -4,7 +4,7 @@ metadata:
   devicecode: zerofltexx 
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         As a first step, you need to boot into the bootloader. A bootloader is the piece of software, 
@@ -12,7 +12,7 @@ steps:
         Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons.png

--- a/openandroidinstaller/assets/configs/zeroltexx.yaml
+++ b/openandroidinstaller/assets/configs/zeroltexx.yaml
@@ -4,7 +4,7 @@ metadata:
   devicecode: zeroltexx 
 steps:
   unlock_bootloader:
-  flash_recovery:
+  boot_recovery:
     - type: call_button
       content: >
         As a first step, you need to boot into the bootloader. A bootloader is the piece of software, 
@@ -12,7 +12,7 @@ steps:
         Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
       command: adb_reboot_download
     - type: call_button
-      content: In this step, you need to flash a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
       command: heimdall_flash_recovery
     - type: confirm_button
       img: samsung-buttons.png

--- a/openandroidinstaller/installer_config.py
+++ b/openandroidinstaller/installer_config.py
@@ -70,12 +70,12 @@ class InstallerConfig:
     def __init__(
         self,
         unlock_bootloader: List[Step],
-        flash_recovery: List[Step],
+        boot_recovery: List[Step],
         metadata: dict,
         requirements: dict,
     ):
         self.unlock_bootloader = unlock_bootloader
-        self.flash_recovery = flash_recovery
+        self.boot_recovery = boot_recovery
         self.metadata = metadata
         self.requirements = requirements
         self.device_code = metadata.get("devicecode")
@@ -111,11 +111,11 @@ class InstallerConfig:
             ]
         else:
             unlock_bootloader = []
-        flash_recovery = [
-            Step(**raw_step, title="Flash custom recovery")
-            for raw_step in raw_steps.get("flash_recovery", [])
+        boot_recovery = [
+            Step(**raw_step, title="Boot custom recovery")
+            for raw_step in raw_steps.get("boot_recovery", [])
         ]
-        return cls(unlock_bootloader, flash_recovery, metadata, requirements)
+        return cls(unlock_bootloader, boot_recovery, metadata, requirements)
 
 
 def _load_config(device_code: str, config_path: Path) -> Optional[InstallerConfig]:
@@ -157,7 +157,7 @@ def validate_config(config: str) -> bool:
         ),
         "content": str,
         schema.Optional("command"): Regex(
-            r"adb_reboot|adb_reboot_bootloader|adb_reboot_download|adb_sideload|adb_twrp_wipe_and_install|adb_twrp_copy_partitions|fastboot_flash_recovery|fastboot_flash_boot|fastboot_unlock_with_code|fastboot_get_unlock_data|fastboot_unlock|fastboot_oem_unlock|fastboot_reboot|heimdall_flash_recovery"
+            r"adb_reboot|adb_reboot_bootloader|adb_reboot_download|adb_sideload|adb_twrp_wipe_and_install|adb_twrp_copy_partitions|fastboot_boot_recovery|fastboot_flash_boot|fastboot_unlock_with_code|fastboot_get_unlock_data|fastboot_unlock|fastboot_oem_unlock|fastboot_reboot|heimdall_flash_recovery"
         ),
         schema.Optional("allow_skip"): bool,
         schema.Optional("img"): str,
@@ -178,7 +178,7 @@ def validate_config(config: str) -> bool:
             },
             "steps": {
                 "unlock_bootloader": schema.Or(None, [step_schema]),
-                "flash_recovery": [step_schema],
+                "boot_recovery": [step_schema],
             },
         }
     )

--- a/openandroidinstaller/tooling.py
+++ b/openandroidinstaller/tooling.py
@@ -250,7 +250,7 @@ def adb_twrp_wipe_and_install(
             for line in adb_reboot_bootloader(bin_path):
                 yield line
             # boot to TWRP again
-            for line in fastboot_flash_recovery(
+            for line in fastboot_boot_recovery(
                 bin_path=bin_path, recovery=recovery, is_ab=is_ab
             ):
                 yield line
@@ -354,7 +354,7 @@ def fastboot_reboot(bin_path: Path) -> TerminalResponse:
 
 
 @add_logging("Boot custom recovery with fastboot.")
-def fastboot_flash_recovery(
+def fastboot_boot_recovery(
     bin_path: Path, recovery: str, is_ab: bool = True
 ) -> TerminalResponse:
     """Temporarily, boot custom recovery with fastboot."""
@@ -423,8 +423,8 @@ def heimdall_flash_recovery(bin_path: Path, recovery: str) -> TerminalResponse:
     """Temporarily, flash custom recovery with heimdall."""
     for line in run_command(
         "heimdall flash --no-reboot --RECOVERY", target=f"{recovery}", bin_path=bin_path
-    ):
-        yield line
+    ):boot_recovery
+    yield line
 
 
 def search_device(platform: str, bin_path: Path) -> Optional[str]:

--- a/openandroidinstaller/tooling.py
+++ b/openandroidinstaller/tooling.py
@@ -353,36 +353,32 @@ def fastboot_reboot(bin_path: Path) -> TerminalResponse:
         yield line
 
 
-@add_logging("Flash or boot custom recovery with fastboot.")
+@add_logging("Boot custom recovery with fastboot.")
 def fastboot_flash_recovery(
     bin_path: Path, recovery: str, is_ab: bool = True
 ) -> TerminalResponse:
-    """Temporarily, flash custom recovery with fastboot."""
+    """Temporarily, boot custom recovery with fastboot."""
     if is_ab:
         logger.info("Boot custom recovery with fastboot.")
         for line in run_command(
             "fastboot boot", target=f"{recovery}", bin_path=bin_path
         ):
             yield line
+        logger.info("Boot into TWRP with fastboot.")
         for line in adb_wait_for_recovery(bin_path=bin_path):
             yield line
     else:
-        logger.info("Flash custom recovery with fastboot.")
+        logger.info("Boot custom recovery with fastboot.")
         for line in run_command(
-            "fastboot flash recovery", target=f"{recovery}", bin_path=bin_path
+            "fastboot boot", target=f"{recovery}", bin_path=bin_path
         ):
             yield line
-        for line in adb_wait_for_recovery(bin_path=bin_path):
-            yield line
         if (type(line) == bool) and not line:
-            logger.error("Flashing recovery failed.")
+            logger.error("Booting recovery failed.")
             yield False
         else:
             yield True
-        # reboot
         logger.info("Boot into TWRP with fastboot.")
-        for line in run_command("fastboot reboot recovery", bin_path):
-            yield line
         for line in adb_wait_for_recovery(bin_path=bin_path):
             yield line
 

--- a/openandroidinstaller/views/start_view.py
+++ b/openandroidinstaller/views/start_view.py
@@ -99,13 +99,13 @@ Now you are ready to continue.
             """Enable skipping unlocking the bootloader if selected."""
             if self.bootloader_switch.value:
                 logger.info("Skipping bootloader unlocking.")
-                self.state.steps = copy.deepcopy(self.state.config.flash_recovery)
+                self.state.steps = copy.deepcopy(self.state.config.boot_recovery)
                 self.state.num_total_steps = len(self.state.steps)
             else:
                 logger.info("Enabled unlocking the bootloader again.")
                 self.state.steps = copy.deepcopy(
                     self.state.config.unlock_bootloader
-                ) + copy.deepcopy(self.state.config.flash_recovery)
+                ) + copy.deepcopy(self.state.config.boot_recovery)
                 self.state.num_total_steps = len(self.state.steps)
 
         self.bootloader_switch = Switch(

--- a/openandroidinstaller/views/step_view.py
+++ b/openandroidinstaller/views/step_view.py
@@ -106,7 +106,7 @@ class StepView(BaseView):
         # main controls
         steps_indictor_img_lookup = {
             "Unlock the bootloader": "steps-header-unlock.png",
-            "Flash custom recovery": "steps-header-recovery.png",
+            "Boot custom recovery": "steps-header-recovery.png",
         }
         self.right_view_header.controls = [
             get_title(

--- a/openandroidinstaller/views/step_view.py
+++ b/openandroidinstaller/views/step_view.py
@@ -38,7 +38,7 @@ from tooling import (
     adb_reboot_download,
     adb_sideload,
     adb_twrp_copy_partitions,
-    fastboot_flash_recovery,
+    fastboot_boot_recovery,
     fastboot_flash_boot,
     fastboot_oem_unlock,
     fastboot_reboot,
@@ -217,8 +217,8 @@ class StepView(BaseView):
             ),
             "fastboot_oem_unlock": fastboot_oem_unlock,
             "fastboot_get_unlock_data": fastboot_get_unlock_data,
-            "fastboot_flash_recovery": partial(
-                fastboot_flash_recovery,
+            "fastboot_boot_recovery": partial(
+                fastboot_boot_recovery,
                 recovery=self.state.recovery_path,
                 is_ab=self.state.is_ab,
             ),


### PR DESCRIPTION
OAI now only boots into TWRP instead of flashing and overwriting the existing recovery, which can cause problems with the bootloader not being able to communicate with the recovery.

related to https://github.com/openandroidinstaller-dev/openandroidinstaller/pull/98#issuecomment-1465231721