### PR TITLE
Support for Samsung Galaxy Grand Prime VE

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Samsung | Galaxy J7 2015 | j7elte | | tested
 Samsung | Galaxy A3 2017 | a3y17lte | SM-A320FL | tested
 Samsung | Galaxy A5 2016 | [a5xelte](https://wiki.lineageos.org/devices/a5xelte) | SM-A510F | tested
 Samsung | Galaxy A7 2016 | a7xelte | | tested
+Samsung | Galaxy Grand Prime VE | grandprimevelte | SM-G531F | untested
 Samsung | Galaxy S III Neo | s3ve3g | GT-I9301I | tested
 Samsung | Galaxy S4 Mini LTE| [serranoltexx](https://wiki.lineageos.org/devices/serranoltexx) | | tested
 Samsung | Galaxy S6 | [zerofltexx](https://wiki.lineageos.org/devices/zerofltexx) | | tested

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Samsung | Galaxy J7 2015 | j7elte | | tested
 Samsung | Galaxy A3 2017 | a3y17lte | SM-A320FL | tested
 Samsung | Galaxy A5 2016 | [a5xelte](https://wiki.lineageos.org/devices/a5xelte) | SM-A510F | tested
 Samsung | Galaxy A7 2016 | a7xelte | | tested
-Samsung | Galaxy Grand Prime VE | grandprimevelte | SM-G531F | untested
+Samsung | Galaxy Grand Prime VE | grandprimevelte | SM-G531F | tested
 Samsung | Galaxy S III Neo | s3ve3g | GT-I9301I | tested
 Samsung | Galaxy S4 Mini LTE| [serranoltexx](https://wiki.lineageos.org/devices/serranoltexx) | | tested
 Samsung | Galaxy S6 | [zerofltexx](https://wiki.lineageos.org/devices/zerofltexx) | | tested

--- a/openandroidinstaller/assets/configs/grandprimevelte.yaml
+++ b/openandroidinstaller/assets/configs/grandprimevelte.yaml
@@ -1,0 +1,28 @@
+metadata:
+  maintainer: MagicLike
+  device_name: Samsung Galaxy Grand Prime VE
+  is_ab_device: false
+  device_code: grandprimevelte
+  supported_device_codes:
+    - grandprimevelte
+  twrp-link: grandprimevelte
+requirements:
+  android: 5.1.1
+steps:
+  unlock_bootloader:
+  boot_recovery:
+    - type: call_button
+      content: >
+        As a first step, you need to boot into the bootloader. A bootloader is the piece of software, 
+        that tells your phone who to start and run an operating system (like Android). Your device should be turned on. 
+        Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
+      command: adb_reboot_download
+    - type: call_button
+      content: In this step, you need to boot a custom recovery on your device. Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      command: heimdall_flash_recovery
+    - type: confirm_button
+      img: samsung-buttons.png
+      content: >
+        Unplug the USB cable from your device. Then manually reboot into recovery by pressing the *Volume Down* + *Power buttons* for 8~10 seconds 
+        until the screen turns black & release the buttons immediately when it does, then boot to recovery with the device powered off, 
+        hold *Volume Up* + *Home* + *Power button*.


### PR DESCRIPTION
Added a config for the Samsung Galaxy Grand Prime VE (`grandprimevelte`), but I was not able to test it yet, as the device is not officially supported by LineageOS.