### PR TITLE
If adb twrp format data fails, retry with adb twrp wipe data

### DIFF
--- a/openandroidinstaller/tooling.py
+++ b/openandroidinstaller/tooling.py
@@ -177,18 +177,11 @@ def adb_twrp_copy_partitions(bin_path: Path, config_path: Path) -> TerminalRespo
 
 @add_logging("Perform a factory reset with adb and twrp.", return_if_fail=True)
 def adb_twrp_format_data(bin_path: Path) -> TerminalResponse:
-    """Perform a factory reset with twrp and adb."""
-    for line in run_command("adb shell twrp format data", bin_path):
-        yield line
-
-
-@add_logging("Wipe the selected partition with adb and twrp.", return_if_fail=True)
-def adb_twrp_wipe_partition(bin_path: Path, partition: str) -> TerminalResponse:
     """Perform a factory reset with twrp and adb.
 
     If `format data` fails (for example because of old TWRP versions) we fall back to `wipe data`.
     """
-    for line in run_command(f"adb shell twrp wipe {partition}", bin_path):
+    for line in run_command("adb shell twrp format data", bin_path):
         yield line
     if (type(line) == bool) and not line:
         logger.info(
@@ -197,6 +190,13 @@ def adb_twrp_wipe_partition(bin_path: Path, partition: str) -> TerminalResponse:
         sleep(1)
         for line in adb_twrp_wipe_partition(bin_path=bin_path, partition="data"):
             yield line
+
+
+@add_logging("Wipe the selected partition with adb and twrp.", return_if_fail=True)
+def adb_twrp_wipe_partition(bin_path: Path, partition: str) -> TerminalResponse:
+    """Perform a factory reset with twrp and adb."""
+    for line in run_command(f"adb shell twrp wipe {partition}", bin_path):
+        yield line
 
 
 def adb_twrp_wipe_and_install(

--- a/openandroidinstaller/tooling.py
+++ b/openandroidinstaller/tooling.py
@@ -181,9 +181,14 @@ def adb_twrp_format_data(bin_path: Path) -> TerminalResponse:
 
     If `format data` fails (for example because of old TWRP versions) we fall back to `wipe data`.
     """
+    unknown_command = False
     for line in run_command("adb shell twrp format data", bin_path):
+        if "Unrecognized script command" in line:
+            unknown_command = True
         yield line
-    if (type(line) == bool) and not line:
+    
+    # if it fails because the command is unknown, retry with wipe data.
+    if unknown_command:
         logger.info(
             "Factory reset with `adb twrp format data` failed. Trying `adb twrp wipe data` now."
         )

--- a/openandroidinstaller/tooling.py
+++ b/openandroidinstaller/tooling.py
@@ -186,7 +186,7 @@ def adb_twrp_format_data(bin_path: Path) -> TerminalResponse:
         if (type(line) == str) and ("Unrecognized script command" in line):
             unknown_command = True
         yield line
-    
+
     # if it fails because the command is unknown, retry with wipe data.
     if unknown_command:
         logger.info(

--- a/openandroidinstaller/tooling.py
+++ b/openandroidinstaller/tooling.py
@@ -183,7 +183,7 @@ def adb_twrp_format_data(bin_path: Path) -> TerminalResponse:
     """
     unknown_command = False
     for line in run_command("adb shell twrp format data", bin_path):
-        if "Unrecognized script command" in line:
+        if (type(line) == str) and ("Unrecognized script command" in line):
             unknown_command = True
         yield line
     

--- a/openandroidinstaller/views/addon_view.py
+++ b/openandroidinstaller/views/addon_view.py
@@ -80,7 +80,6 @@ The recommended way to install MicroG is to use the zip file provided here:
 F-Droid is an installable catalogue of libre software apps for Android. The F-Droid client app makes it easy to browse, install, and keep track of updates on your device.
 You can get the zip file to install this addon here: [https://f-droid.org/en/packages/org.fdroid.fdroid.privileged.ota](https://f-droid.org/en/packages/org.fdroid.fdroid.privileged.ota).
 """,
-                on_tap_link=lambda e: self.page.launch_url(e.data),
             ),
             actions=[
                 TextButton("Close", on_click=self.close_close_explain_addons_dlg),

--- a/openandroidinstaller/views/success_view.py
+++ b/openandroidinstaller/views/success_view.py
@@ -59,7 +59,6 @@ Also, you can consider contributing to make it better. There are a lot of differ
 
 [How to contribute]({contribute_link})
 """,
-                on_tap_link=lambda e: self.page.launch_url(e.data),
             ),
             Row(
                 [


### PR DESCRIPTION
If `adb twrp format data` fails, retry with `adb twrp wipe data`. This should address issues with old versions of TWRP as found in #140.