### PR TITLE
add a5 2017

### DIFF
--- a/openandroidinstaller/assets/configs/a5y17lte.yaml
+++ b/openandroidinstaller/assets/configs/a5y17lte.yaml
@@ -1,0 +1,27 @@
+metadata:
+  maintainer: Tobias Sterbak (tsterbak)
+  device_name: Samsung Galaxy A5 (2017)
+  is_ab_device: false 
+  device_code: a5y17lte
+  supported_device_codes:
+    - a5y17lte
+steps:
+  unlock_bootloader:
+  boot_recovery:
+    - type: call_button
+      content: >
+        As a first step, you need to boot into the bootloader. A bootloader is the piece of software, 
+        that tells your phone how to start and run an operating system (like Android). Your device should be turned on. 
+        Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
+      command: adb_reboot_download
+    - type: call_button
+      content: >
+        In this step, you need to flash a custom recovery on your device.
+        Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      command: heimdall_flash_recovery
+    - type: confirm_button
+      img: samsung-buttons.png
+      content: >
+        Unplug the USB cable from your device. Then manually reboot into recovery by pressing the *Volume Down* + *Power buttons* for 8~10 seconds 
+        until the screen turns black & release the buttons immediately when it does, then boot to recovery with the device powered off, 
+        hold *Volume Up* + *Home* + *Power button*.


### PR DESCRIPTION
I could install /e/OS out of the box by copying the A5 2016 config. And with : 
- custom recovery :  https://dl.twrp.me/a5y17lte/twrp-3.7.0_9-0-a5y17lte.img.html
- /e/OS 1.11 : https://images.ecloud.global/dev/a5y17lte/e-1.11-r-20230512289175-dev-a5y17lte.zip