### PR TITLE
Add support for Pixel 6a (bluejay)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Google | Pixel 4 XL | [coral](https://wiki.lineageos.org/devices/coral) | coral 
 Google | Pixel 4a | [sunfish](https://wiki.lineageos.org/devices/sunfish) | sunfish | tested 
 Google | Pixel 5 | [redfin](https://wiki.lineageos.org/devices/redfin) | redfin | tested
 Google | Pixel 5a | [barbet](https://wiki.lineageos.org/devices/barbet) | barbet | tested
+Google | Pixel 6a | [bluejay](https://wiki.lineageos.org/devices/bluejay) | bluejay | tested
 </details>
 
 <details><summary><b>Sony</b></summary>

--- a/openandroidinstaller/assets/configs/bluejay.yaml
+++ b/openandroidinstaller/assets/configs/bluejay.yaml
@@ -1,0 +1,54 @@
+metadata:
+  maintainer: Tejas Raman (tejasraman)
+  device_name: Pixel 6a
+  is_ab_device: true
+  device_code: bluejay
+  supported_device_codes:
+    - bluejay 
+requirements:
+  android: 13.0.0
+steps:
+  unlock_bootloader:
+    - type: confirm_button
+      content: >
+        As a first step, you need to unlock the bootloader. A bootloader is the piece of software, that tells your phone
+        how to start and run an operating system (like Android). Your device should be turned on.
+    - type: call_button
+      content: >
+        Press 'Confirm and run' to reboot into the bootloader.
+      command: adb_reboot_bootloader
+    - type: confirm_button
+      content: >
+        Select 'Restart bootloader' on your smartphone screen by pressing the volume button and the confirm by pushing the power button.
+        Then press 'Confirm and continue' here.
+    - type: call_button
+      content: >
+        In this step you actually unlock the bootloader. Just press 'Confirm and run' here. Once it's done, press continue here.
+      command: fastboot_unlock
+    - type: confirm_button
+      content: >
+        At this point the device may display on-screen prompts which will require interaction to continue the process of unlocking the bootloader.
+        Please take whatever actions the device asks you to to proceed.
+    - type: call_button
+      content: >
+        To finish the unlocking, the phone needs to reboot. Just press 'Confirm and run' here to reboot. Then continue.
+      command: fastboot_reboot
+    - type: confirm_button
+      content: >
+        The bootloader is now unlocked. Since the device resets completely, you will need to re-enable USB debugging to continue. To do so, please enable "Developer options" in Settings again and enable USB debugging there
+  boot_recovery:
+    - type: confirm_button 
+      content: >
+        Now you need to boot a custom recovery system on the phone. A recovery is a piece of software that lets you reset and manage your system OS.
+    - type: call_button
+      content: >
+        Once the device is fully booted, you need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
+      command: adb_reboot_bootloader
+    - type: confirm_button
+      content: >
+        Select 'Restart bootloader' on your smartphone screen. Then confirm to continue.
+    - type: call_button
+      img: twrp-start.jpeg
+      content: >
+        Boot a custom recovery (temporarily) by pressing 'Confirm and run'. Once it's done, continue.
+      command: fastboot_boot_recovery


### PR DESCRIPTION
Adds configuration file for Pixel 6a (bluejay). Process for unlocking BL is extremely similar to that of the Pixel 5a (barbet). 

I set the required Android version to 13.0.0 (as firmware was changed for Tensor-based devices with A13). Config files for 6a should also work with 6 and 6 pro (if modified).

Tested and working here @tsterbak 