### PR TITLE
Actions update

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Display structure of downloaded files
       run: ls -R
     - name: Create release
-      uses: dciborow/action-github-releases@latest
+      uses: dciborow/action-github-releases@v1
       if: startsWith(github.ref, 'refs/tags/')
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Display structure of downloaded files
       run: ls -R
     - name: Create release
-      uses: dciborow/action-github-releases@v1
+      uses: dciborow/action-github-releases@v1.0.1
       if: startsWith(github.ref, 'refs/tags/')
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -86,7 +86,7 @@ jobs:
     - name: Display structure of downloaded files
       run: ls -R
     - name: Create release
-      uses: marvinpinto/action-automatic-releases@latest
+      uses: dciborow/action-github-releases@latest
       if: startsWith(github.ref, 'refs/tags/')
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,8 +14,8 @@ jobs:
       matrix:
         os: ['ubuntu-20.04', 'ubuntu-latest']
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - run: pip install -r requirements.txt
@@ -32,8 +32,8 @@ jobs:
       matrix:
         os: ['ubuntu-20.04', 'ubuntu-latest', 'macos-latest']
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - run: pip install -r requirements.txt
@@ -48,8 +48,8 @@ jobs:
     needs: ci
     runs-on: 'windows-latest'
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - run: pip install -r requirements.txt
@@ -66,7 +66,7 @@ jobs:
       - build-windows
     runs-on: 'ubuntu-latest'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Download artifact
       uses: actions/download-artifact@v3
     - name: Display structure of downloaded files

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.9
     - run: pip install -r requirements.txt
     - run: python scripts/download-tools.py
     - run: black .
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.9
     - run: pip install -r requirements.txt
     - run: python scripts/download-tools.py
     - run: python scripts/build.py
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.9
     - run: pip install -r requirements.txt
     - run: python scripts/download-tools.py
     - run: python scripts/build.py

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - run: pip install -r requirements.txt
     - run: python scripts/download-tools.py
     - run: black .
@@ -35,7 +35,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - run: pip install -r requirements.txt
     - run: python scripts/download-tools.py
     - run: python scripts/build.py
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: 3.11
     - run: pip install -r requirements.txt
     - run: python scripts/download-tools.py
     - run: python scripts/build.py

--- a/.github/workflows/manual-build.yml
+++ b/.github/workflows/manual-build.yml
@@ -13,8 +13,8 @@ jobs:
         os: ['ubuntu-20.04', 'ubuntu-latest', 'macos-latest', 'windows-latest']
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.9
     - run: pip install -r requirements.txt


### PR DESCRIPTION
As seen in the warnings of GitHub Actions after running the [latest ci build](https://github.com/openandroidinstaller-dev/openandroidinstaller/actions/runs/5667887930), it needs an update.
![grafik](https://github.com/openandroidinstaller-dev/openandroidinstaller/assets/82117109/0dacf559-f6d5-4a16-a964-1efc0b8cbac8)

TODO:

- [x] Update checkout
- [x] Update setup-python
- [x] Update automatic-releases
- [ ] ~~Update Python version(?)~~

---

See my latest test build here: https://github.com/MagicLike/openandroidinstaller/actions/runs/5685471674
![grafik](https://github.com/openandroidinstaller-dev/openandroidinstaller/assets/82117109/8e1ed088-e72e-4bb0-9610-518b4d1e2940)
