### PR TITLE
[SPLIT] Add dtbo, vbmeta, super_empty flashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Every config file should have `metadata` with the following fields:
 - `device_code`: str; The official device code.
 - `supported_device_codes`: List[str]; A list of supported device codes for the config. The config will be loaded based on this field.
 - `twrp-link`: [OPTIONAL] str; name of the corresponding twrp page.
+- `additional_steps` : [OPTIONAL] List[str]; A list of additional steps. Could be `dtbo`, `vbmeta`, `super_empty`.
 
 In addition to these metadata, every config can have optional `requirements`. If these are set, the user is asked to check if they are meet.
 - `android`: [OPTIONAL] int|str; Android version to install prior to installing a custom ROM.
@@ -231,7 +232,7 @@ Every step in the config file corresponds to one view in the application. These 
 - `img`: [OPTIONAL] Display an image on the left pane of the step view. Images are loaded from `openandroidinstaller/assets/imgs/`.
 - `content`: str; The content text displayed alongside the action of the step. Used to inform the user about what's going on. For consistency and better readability the text should be moved into the next line using `>`.
 - `link`: [OPTIONAL] Link to use for the link button if type is `link_button_with_confirm`.
-- `command`: [ONLY for call_button* steps] str; The command to run. One of `adb_reboot`, `adb_reboot_bootloader`, `adb_reboot_download`, `adb_sideload`, `adb_twrp_wipe_and_install`, `adb_twrp_copy_partitions`, `fastboot_boot_recovery`, `fastboot_unlock_with_code`, `fastboot_unlock`, `fastboot_oem_unlock`, `fastboot_get_unlock_data`, `fastboot_reboot`, `heimdall_flash_recovery`.
+- `command`: [ONLY for call_button* steps] str; The command to run. One of `adb_reboot`, `adb_reboot_bootloader`, `adb_reboot_download`, `adb_sideload`, `adb_twrp_wipe_and_install`, `adb_twrp_copy_partitions`, `fastboot_boot_recovery`, `fastboot_flash_additional_partitions`, `fastboot_unlock_with_code`, `fastboot_unlock`, `fastboot_oem_unlock`, `fastboot_get_unlock_data`, `fastboot_reboot`, `heimdall_flash_recovery`.
 - `allow_skip`: [OPTIONAL] boolean; If a skip button should be displayed to allow skipping this step. Can be useful when the bootloader is already unlocked.
 
 **Please try to retain this order of these fields in your config to ensure consistency.**

--- a/openandroidinstaller/app_state.py
+++ b/openandroidinstaller/app_state.py
@@ -44,6 +44,9 @@ class AppState:
         self.config = None
         self.image_path = None
         self.recovery_path = None
+        self.dtbo_path = None
+        self.vbmeta_path = None
+        self.super_empty_path = None
 
         # store views
         self.default_views: List = []

--- a/openandroidinstaller/installer_config.py
+++ b/openandroidinstaller/installer_config.py
@@ -62,6 +62,7 @@ class InstallerConfig:
         self.requirements = requirements
         self.device_code = metadata.get("device_code")
         self.is_ab = metadata.get("is_ab_device", False)
+        self.additional_steps = metadata.get("additional_steps")
         self.supported_device_codes = metadata.get("supported_device_codes")
         self.twrp_link = metadata.get("twrp-link")
 
@@ -134,6 +135,8 @@ def _load_config(device_code: str, config_path: Path) -> Optional[InstallerConfi
             config = InstallerConfig.from_file(path)
             logger.info(f"Loaded device config from {path}.")
             if config:
+                if "additional_steps" not in config.metadata:
+                    config.metadata.update({"additional_steps": "[]"})
                 logger.info(f"Config metadata: {config.metadata}.")
             return config
         else:
@@ -150,7 +153,7 @@ def validate_config(config: str) -> bool:
         ),
         "content": str,
         schema.Optional("command"): Regex(
-            r"adb_reboot|adb_reboot_bootloader|adb_reboot_download|adb_sideload|adb_twrp_wipe_and_install|adb_twrp_copy_partitions|fastboot_boot_recovery|fastboot_flash_boot|fastboot_unlock_with_code|fastboot_get_unlock_data|fastboot_unlock|fastboot_oem_unlock|fastboot_reboot|heimdall_flash_recovery"
+            r"adb_reboot|adb_reboot_bootloader|adb_reboot_download|adb_sideload|adb_twrp_wipe_and_install|adb_twrp_copy_partitions|fastboot_boot_recovery|fastboot_flash_boot|fastboot_unlock_with_code|fastboot_get_unlock_data|fastboot_unlock|fastboot_oem_unlock|fastboot_reboot|heimdall_flash_recovery|fastboot_flash_additional_partitions"
         ),
         schema.Optional("allow_skip"): bool,
         schema.Optional("img"): str,
@@ -166,6 +169,7 @@ def validate_config(config: str) -> bool:
                 "device_code": str,
                 "supported_device_codes": [str],
                 schema.Optional("twrp-link"): str,
+                schema.Optional("additional_steps"): [str],
             },
             schema.Optional("requirements"): {
                 schema.Optional("android"): schema.Or(str, int),

--- a/openandroidinstaller/tooling.py
+++ b/openandroidinstaller/tooling.py
@@ -497,3 +497,54 @@ def search_device(platform: str, bin_path: Path) -> Optional[str]:
     except CalledProcessError:
         logger.error("Failed to detect a device.")
         return None
+
+
+@add_logging("Flash additional partitions with fastboot")
+def fastboot_flash_additional_partitions(
+    bin_path: Path, dtbo: str, vbmeta: str, super_empty: str, is_ab: bool = True
+) -> TerminalResponse:
+    """Flash additional partitions (dtbo, vbmeta, super_empty) with fastboot."""
+    if dtbo:
+        for line in run_command(
+            "fastboot flash dtbo ", target=f"{dtbo}", bin_path=bin_path
+        ):
+            yield line
+        if not is_ab:
+            if (type(line) == bool) and not line:
+                logger.error("Flashing dtbo failed.")
+                yield False
+            else:
+                yield True
+    else:
+        logger.info("No dtbo selected. Skipping")
+        yield True
+
+    if vbmeta:
+        for line in run_command(
+            "fastboot flash vbmeta ", target=f"{vbmeta}", bin_path=bin_path
+        ):
+            yield line
+        if not is_ab:
+            if (type(line) == bool) and not line:
+                logger.error("Flashing vbmeta failed.")
+                yield False
+            else:
+                yield True
+    else:
+        logger.info("No vbmeta selected. Skipping")
+        yield True
+
+    if super_empty:
+        for line in run_command(
+            "fastboot wipe-super ", target=f"{super_empty}", bin_path=bin_path
+        ):
+            yield line
+        if not is_ab:
+            if (type(line) == bool) and not line:
+                logger.error("Wiping super failed.")
+                yield False
+            else:
+                yield True
+    else:
+        logger.info("No super_empty selected. Skipping")
+        yield True

--- a/openandroidinstaller/utils.py
+++ b/openandroidinstaller/utils.py
@@ -59,6 +59,20 @@ def image_works_with_device(supported_device_codes: List[str], image_path: str) 
                 )
                 return False
 
+def image_sdk_level(image_path: str) -> int:
+    """
+    Determine Android version of the selected image.
+    Android 13 : 33
+    """
+    with zipfile.ZipFile(image_path) as image_zip:
+        with image_zip.open(
+            "META-INF/com/android/metadata", mode="r"
+        ) as image_metadata:
+            metadata = image_metadata.readlines()
+            for line in metadata:
+                if b"sdk-level" in line:
+                    return int(line[line.find(b'=')+1:-1].decode("utf-8"))
+    return 0
 
 def recovery_works_with_device(device_code: str, recovery_path: str) -> bool:
     """Determine if a recovery works for the given device.

--- a/openandroidinstaller/views/step_view.py
+++ b/openandroidinstaller/views/step_view.py
@@ -45,6 +45,7 @@ from tooling import (
     adb_twrp_copy_partitions,
     fastboot_boot_recovery,
     fastboot_flash_boot,
+    fastboot_flash_additional_partitions,
     fastboot_oem_unlock,
     fastboot_reboot,
     fastboot_unlock,
@@ -230,6 +231,13 @@ class StepView(BaseView):
             "fastboot_flash_boot": partial(
                 fastboot_flash_boot,
                 recovery=self.state.recovery_path,
+            ),
+            "fastboot_flash_additional_partitions": partial(
+                fastboot_flash_additional_partitions,
+                dtbo=self.state.dtbo_path,
+                vbmeta=self.state.vbmeta_path,
+                super_empty=self.state.super_empty_path,
+                is_ab=self.state.config.is_ab,
             ),
             "fastboot_reboot": fastboot_reboot,
             "heimdall_flash_recovery": partial(


### PR DESCRIPTION
Allow user to flash dtbo, vbmeta and super_empty if needed : 
Buttons shows off only if asked in device config file, and are optional, because it depends on the ROM (especially android version wanted)

Work started and tested in #188 but not in this PR alone (it's a copy and paste, so if I didn't forget something, it will work)