### PR TITLE
[SPLIT] Added optional device specific notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,12 +210,14 @@ A config file consists of two parts. The first part are some metadata about the 
 ##### How to write Metadata
 Every config file should have `metadata` with the following fields:
 - `maintainer`: str; Maintainer and author of the config file.
+- `brand`: [OPTIONAL] str; Name of the brand. Can be used to make brand specific actions.
 - `device_name`: str; Name of the device.
 - `is_ab_device`: bool; A boolean to determine if the device is a/b-partitioned or not.
 - `device_code`: str; The official device code.
 - `supported_device_codes`: List[str]; A list of supported device codes for the config. The config will be loaded based on this field.
 - `twrp-link`: [OPTIONAL] str; name of the corresponding twrp page.
-- `notes`: [OPTIONAL] str; specific phone information, showed before choosing ROM / recovery
+- `notes`: [OPTIONAL] List[str]; specific phone information, showed before choosing ROM / recovery
+- `untested`: [OPTIONAL] bool; If `true`, a warning message is showed during installation process.
 
 In addition to these metadata, every config can have optional `requirements`. If these are set, the user is asked to check if they are meet.
 - `android`: [OPTIONAL] int|str; Android version to install prior to installing a custom ROM.

--- a/README.md
+++ b/README.md
@@ -215,6 +215,7 @@ Every config file should have `metadata` with the following fields:
 - `device_code`: str; The official device code.
 - `supported_device_codes`: List[str]; A list of supported device codes for the config. The config will be loaded based on this field.
 - `twrp-link`: [OPTIONAL] str; name of the corresponding twrp page.
+- `notes`: [OPTIONAL] str; specific phone information, showed before choosing ROM / recovery
 
 In addition to these metadata, every config can have optional `requirements`. If these are set, the user is asked to check if they are meet.
 - `android`: [OPTIONAL] int|str; Android version to install prior to installing a custom ROM.

--- a/openandroidinstaller/installer_config.py
+++ b/openandroidinstaller/installer_config.py
@@ -166,6 +166,7 @@ def validate_config(config: str) -> bool:
                 "device_code": str,
                 "supported_device_codes": [str],
                 schema.Optional("twrp-link"): str,
+                schema.Optional("notes"): str,
             },
             schema.Optional("requirements"): {
                 schema.Optional("android"): schema.Or(str, int),

--- a/openandroidinstaller/views/select_view.py
+++ b/openandroidinstaller/views/select_view.py
@@ -147,6 +147,13 @@ OpenAndroidInstaller works with the [TWRP recovery project](https://twrp.me/abou
 
         # Device specific notes
         if "notes" in self.state.config.metadata:
+            notes = ""
+            if "brand" in self.state.config.metadata and (self.state.config.metadata['brand'] == "xiaomi" or self.state.config.metadata['brand'] == "poco"):
+                notes += "- If something goes wrong, you can reinstall MiUI here :\n<https://xiaomifirmwareupdater.com/miui/lavender/>\n\n"
+            if "untested" in self.state.config.metadata and self.state.config.metadata['untested'] == True:
+                notes += "- **This device has never been tested with OpenAndroidInstaller.** The installation can go wrong. You may have to finish the installation process with command line. If you test, please report the result on GitHub.\n\n"
+            for note in self.state.config.metadata['notes']:
+                notes += "- " + note + "\n\n"
             self.right_view.controls.extend(
                 [
                     Text(
@@ -155,7 +162,7 @@ OpenAndroidInstaller works with the [TWRP recovery project](https://twrp.me/abou
                         color=colors.RED,
                         weight="bold",
                     ),
-                    Markdown(f"""{self.state.config.metadata['notes']}"""),
+                    Markdown(f"""{notes}"""),
                 ]
             )
         # if there is an available download, show the button to the page

--- a/openandroidinstaller/views/select_view.py
+++ b/openandroidinstaller/views/select_view.py
@@ -144,6 +144,20 @@ OpenAndroidInstaller works with the [TWRP recovery project](https://twrp.me/abou
 
         # text row to show infos during the process
         self.info_field = Row()
+
+        # Device specific notes
+        if "notes" in self.state.config.metadata:
+            self.right_view.controls.extend(
+                [
+                    Text(
+                        "Important notes for your device",
+                        style="titleSmall",
+                        color=colors.RED,
+                        weight="bold",
+                    ),
+                    Markdown(f"""{self.state.config.metadata['notes']}"""),
+                ]
+            )
         # if there is an available download, show the button to the page
         if self.download_link:
             twrp_download_link = f"https://dl.twrp.me/{self.state.config.twrp_link if self.state.config.twrp_link else self.state.config.device_code}"

--- a/openandroidinstaller/views/select_view.py
+++ b/openandroidinstaller/views/select_view.py
@@ -146,14 +146,16 @@ OpenAndroidInstaller works with the [TWRP recovery project](https://twrp.me/abou
         self.info_field = Row()
 
         # Device specific notes
+        notes = ""
+        if "brand" in self.state.config.metadata and (
+                self.state.config.metadata['brand'] == "xiaomi" or self.state.config.metadata['brand'] == "poco"):
+            notes += "- If something goes wrong, you can reinstall MiUI here :\n<https://xiaomifirmwareupdater.com/miui/lavender/>\n\n"
+        if "untested" in self.state.config.metadata and self.state.config.metadata['untested'] == True:
+            notes += "- **This device has never been tested with OpenAndroidInstaller.** The installation can go wrong. You may have to finish the installation process with command line. If you test, please report the result on GitHub.\n\n"
         if "notes" in self.state.config.metadata:
-            notes = ""
-            if "brand" in self.state.config.metadata and (self.state.config.metadata['brand'] == "xiaomi" or self.state.config.metadata['brand'] == "poco"):
-                notes += "- If something goes wrong, you can reinstall MiUI here :\n<https://xiaomifirmwareupdater.com/miui/lavender/>\n\n"
-            if "untested" in self.state.config.metadata and self.state.config.metadata['untested'] == True:
-                notes += "- **This device has never been tested with OpenAndroidInstaller.** The installation can go wrong. You may have to finish the installation process with command line. If you test, please report the result on GitHub.\n\n"
             for note in self.state.config.metadata['notes']:
                 notes += "- " + note + "\n\n"
+        if notes != "":
             self.right_view.controls.extend(
                 [
                     Text(


### PR DESCRIPTION
Added optional device specific notes support. They are shown on top of the ROM choosing page.

Work started in #188 

Tested and working fine.

EDIT : Added optional `brand` and `untested` metadata, as demanded in #114 