### PR TITLE
[SPLIT] Add support for garden (Xiaomi Redmi 9A & co.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,13 @@ OnePlus | Nord N200 | [dre](https://wiki.lineageos.org/devices/dre) | | tested
 OnePlus | 9 | lemonade | | under development
 </details>
 
+<details><summary><b>Xiaomi</b></summary>
+
+Vendor | Device Name | CodeName | Models | Status
+---|---|---|---|---
+Xiaomi | Redmi 9A / 9C / 9AT / 9i / 9A Sport / 10A / 10A Sport | garden / dandelion / blossom / angelican | | tested
+</details>
+
 And more to come!
 
 

--- a/openandroidinstaller/assets/configs/garden.yaml
+++ b/openandroidinstaller/assets/configs/garden.yaml
@@ -1,0 +1,63 @@
+metadata:
+  maintainer: A non (anon)
+  device_name: Xiaomi Redmi 9A / 9C / 9AT / 9i / 9A Sport / 10A / 10A Sport
+  is_ab_device: false
+  device_code: garden
+  supported_recovery:
+    - orangefox
+    - twrp
+  supported_device_codes:
+    - dandelion
+    - garden
+    - blossom
+    - angelican
+  notes: >
+    - If something goes wrong, you can reinstall MiUI here : https://xiaomifirmwareupdater.com
+    
+    - OAI don't support ROM that requires permissiver.
+    
+    - Be careful when choosing OrangeFox version, Android 12 & 13 ROM needs OrangeFox version code with `A12`, for example `R11.1_5_A12`. Android 10 & 11 ROM needs OrangeFox version code without `A12` (bellow on the page)
+requirements:
+  firmware: MiUI 12.5 (Q)
+steps:
+  unlock_bootloader:
+    - type: confirm_button
+      content: >
+        As a first step, you need to unlock the bootloader. A bootloader is the piece of software, that tells your phone
+        how to start and run an operating system (like Android). Your device should be turned on. This will reset your phone.
+    - type: link_button_with_confirm
+      content: >
+        - Create a Mi account on Xiaomi’s website. Beware that one account is only allowed to unlock one unique device every 30 days.
+        
+        - Add a phone number to your Mi account, insert a SIM into your phone.
+        
+        - Enable developer options in `Settings` > `About Phone` by repeatedly tapping MIUI Version.
+        
+        - Link the device to your Mi account in `Settings` > `Additional settings` > `Developer options` > `Mi Unlock status`.
+        
+        - Download the Mi Unlock app with the link bellow (Windows is required to run the app), and follow the instructions provided by the app. It may tell you that you have to wait, usually 7 days. If it does so, please wait the quoted amount of time before continuing to the next step!
+        
+        - After device and Mi account are successfully verified, the bootloader should be unlocked.
+        
+        - Since the device resets completely, you will need to re-enable USB debugging to continue : `Settings` > `Additional settings` > `Developer options` > `USB debugging`
+      link: https://en.miui.com/unlock/download_en.html
+  boot_recovery:
+    - type: confirm_button
+      content: >
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        adapting and repairing of the operating system.
+    - type: call_button
+      content: >
+        Once the device is fully booted, you need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
+      command: adb_reboot_bootloader
+    - type: call_button
+      content: >
+        Install the recovery you chosen before by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_flash_recovery
+    - type: call_button
+      img: ofox.png
+      content: >
+        Reboot to recovery by pressing 'Confirm and run', and hold the Vol+ button of your phone UNTIL you see the recovery.
+        If MiUI starts, you have to start the process again, since MiUI delete the recovery you just flashed.
+        Once it's done continue.
+      command: fastboot_reboot_recovery


### PR DESCRIPTION
Work started and tested in #188 : working

Requirements : 
- #218 for OrangeFox support (especially `fastboot_flash_recovery` and `fastboot_reboot_recovery`
- #221 for device specific notes (optional)