### PR TITLE
add a  final recovery flash after installing the system image

### DIFF
--- a/openandroidinstaller/tooling.py
+++ b/openandroidinstaller/tooling.py
@@ -292,6 +292,11 @@ def adb_twrp_wipe_and_install(
             # if not an a/b-device just stay in twrp
             pass
     else:
+        #recovery might not be installed yet , we reboot to fastboot to flash it
+        for line in fastboot_flash_recovery(
+                bin_path=bin_path, recovery=recovery, is_ab=is_ab
+            ):
+            yield line
         for line in adb_reboot(bin_path=bin_path):
             yield line
 

--- a/openandroidinstaller/tooling.py
+++ b/openandroidinstaller/tooling.py
@@ -297,7 +297,7 @@ def adb_twrp_wipe_and_install(
                 bin_path=bin_path, recovery=recovery, is_ab=is_ab
             ):
             yield line
-        for line in adb_reboot(bin_path=bin_path):
+        for line in fastboot_reboot(bin_path=bin_path):
             yield line
 
 


### PR DESCRIPTION
in a lot of scenario the recovery is not yet installed after the system installation 
This PR ensure that we always flash the recovery after the system to be sure that OTA updates can be done.