### PR TITLE
Add support for violet (Redmi Note 7 Pro)

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ After starting the app you will be prompted to plug your device into your comput
 
 ## Officially supported devices
 
-Currently, the **we support 86 devices** by various vendors and working on adding more soon!
+Currently, the **we support 87 devices** by various vendors and working on adding more soon!
 
 Support for these devices is provided as best effort, but things might still go wrong.
 Help to improve the tool by reporting any issues you might face.
@@ -216,15 +216,17 @@ Xiaomi | Redmi 7A / 8 / 8A / 8A Dual | [Mi439](https://wiki.lineageos.org/device
 Xiaomi | Redmi 9A / 9C / 9AT / 9i / 9A Sport / 10A / 10A Sport | garden / dandelion / blossom / angelican | | tested
 Xiaomi | Redmi 9 / Poco M2 | [lancelot](https://wiki.lineageos.org/devices/lancelot) / galahad / shivan | | untested
 Xiaomi | Redmi Note 7 | [lavender](https://wiki.lineageos.org/devices/lavender) |  | tested
+Xiaomi | Redmi Note 7 Pro | [violet](https://wiki.lineageos.org/devices/violet) |  | untested
 Xiaomi | Redmi Note 8 / 8T | [ginkgo](https://wiki.lineageos.org/devices/ginkgo) / willow |  | untested
 Xiaomi | Redmi Note 8 Pro | begonia |  | untested
 Xiaomi | Redmi Note 9S / 9 Pro / 9 Pro Max / 10 Lite / Poco M2 pro | [miatoll](https://wiki.lineageos.org/devices/lavender) : gram / curtana / excalibur / joyeuse  |  | untested
 Xiaomi | Redmi Note 10S / 11SE / Poco M5S | [rosemary](https://wiki.lineageos.org/devices/rosemary) / maltose / secret /rosemary_p | | untested
+Xiaomi | Redmi Note 10 Pro | [sweet](https://wiki.lineageos.org/devices/sweet) | M2101K6G | tested
 Xiaomi | Mi A2 / Mi 6X | jasmine_sprout |  | untested
 Xiaomi | Mi 8 | [dipper](https://wiki.lineageos.org/devices/dipper) |  | untested
 Xiaomi | Mi 9T / Redmi K20 | [davinci](https://wiki.lineageos.org/devices/davinci) / davinciin |  | untested
 Xiaomi | Redmi K20 Pro / Mi 9T Pro | raphael / raphaelin | | untested
-Xiaomi | Redmi Note 10 Pro | [sweet](https://wiki.lineageos.org/devices/sweet) | M2101K6G | tested
+Xiaomi | Mi 10T / Mi 10T Pro / Redmi K20 | [apollon](https://wiki.lineageos.org/devices/apollon) / apollo |  | untested
 Xiaomi | Redmi K40 / Mi 11X / Poco F3 | [alioth](https://wiki.lineageos.org/devices/alioth) / aliothin |  | untested
 Xiaomi | Poco X3 / X3 NFC | [surya](https://wiki.lineageos.org/devices/surya) / karna |  | untested
 Xiaomi | Poco X3 Pro | [vayu](https://wiki.lineageos.org/devices/vayu) |  | tested

--- a/openandroidinstaller/assets/configs/violet.yaml
+++ b/openandroidinstaller/assets/configs/violet.yaml
@@ -1,0 +1,55 @@
+metadata:
+  maintainer: A non (anon)
+  brand: xiaomi
+  device_name: Xiaomi Redmi Note 7 Pro
+  is_ab_device: false
+  device_code: violet
+  supported_device_codes:
+    - violet
+  untested: true
+  notes:
+    - You should install Android 10 or newer ROM.
+requirements:
+  android: 10 (Q)
+steps:
+  unlock_bootloader:
+    - type: confirm_button
+      content: >
+        As a first step, you need to unlock the bootloader. A bootloader is the piece of software, that tells your phone
+        how to start and run an operating system (like Android). Your device should be turned on. This will reset your phone.
+    - type: link_button_with_confirm
+      content: >
+        - Create a Mi account on Xiaomi’s website. Beware that one account is only allowed to unlock one unique device every 30 days.
+
+        - Add a phone number to your Mi account, insert a SIM into your phone.
+
+        - Enable developer options in `Settings` > `About Phone` by repeatedly tapping MIUI Version.
+
+        - Link the device to your Mi account in `Settings` > `Additional settings` > `Developer options` > `Mi Unlock status`.
+
+        - Download the Mi Unlock app with the link bellow (Windows is required to run the app), and follow the instructions provided by the app. It may tell you that you have to wait, usually 7 days. If it does so, please wait the quoted amount of time before continuing to the next step!
+
+        - After device and Mi account are successfully verified, the bootloader should be unlocked.
+
+        - Since the device resets completely, you will need to re-enable USB debugging to continue : `Settings` > `Additional settings` > `Developer options` > `USB debugging`
+      link: https://en.miui.com/unlock/download_en.html
+  boot_recovery:
+    - type: confirm_button
+      content: >
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        adapting and repairing of the operating system.
+    - type: call_button
+      content: >
+        Once the device is fully booted, you need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
+      command: adb_reboot_bootloader
+    - type: call_button
+      content: >
+        Install the recovery you chosen before by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_flash_recovery
+    - type: call_button
+      img: twrp-start.jpeg
+      content: >
+        Reboot to recovery by pressing 'Confirm and run', and hold the Vol+ button of your phone UNTIL you see the recovery.
+        If MiUI starts, you have to start the process again, since MiUI delete the recovery you just flashed.
+        Once it's done continue.
+      command: fastboot_reboot_recovery


### PR DESCRIPTION
This PR adds support for `violet` (Xiaomi Redmi Note 7 Pro)
Asked in issue #516 

@harshangithub: This is not tested for now, but it should work (same config as https://github.com/openandroidinstaller-dev/openandroidinstaller/pull/222 for instance)
Can you test it please? We can help you if needed.