### PR TITLE
Add support for chime (Redmi 9T &co.)

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Xiaomi | Redmi 9 / Poco M2 | [lancelot](https://wiki.lineageos.org/devices/lance
 Xiaomi | Redmi Note 7 | [lavender](https://wiki.lineageos.org/devices/lavender) |  | tested
 Xiaomi | Redmi Note 8 / 8T | [ginkgo](https://wiki.lineageos.org/devices/ginkgo) / willow |  | untested
 Xiaomi | Redmi Note 8 Pro | begonia |  | untested
+Xiaomi | Redmi Note 9 4G / Redmi 9T / Redmi 9 Power / POCO M3 | chime : citrus / lime / lemon / pomelo / juice |  | untested
 Xiaomi | Redmi Note 9S / 9 Pro / 9 Pro Max / 10 Lite / Poco M2 pro | [miatoll](https://wiki.lineageos.org/devices/lavender) : gram / curtana / excalibur / joyeuse  |  | untested
 Xiaomi | Redmi Note 10S / 11SE / Poco M5S | [rosemary](https://wiki.lineageos.org/devices/rosemary) / maltose / secret /rosemary_p | | untested
 Xiaomi | Mi A2 / Mi 6X | jasmine_sprout |  | untested

--- a/openandroidinstaller/assets/configs/chime.yaml
+++ b/openandroidinstaller/assets/configs/chime.yaml
@@ -1,0 +1,56 @@
+metadata:
+  maintainer: A non (anon)
+  brand: xiaomi
+  device_name: Xiaomi Redmi Note 9 4G / Redmi 9T / Redmi 9 Power / POCO M3
+  is_ab_device: false
+  untested: true
+  device_code: chime
+  supported_device_codes:
+    - chime
+    - citrus
+    - lime
+    - lemon
+    - pomelo
+    - juice
+steps:
+  unlock_bootloader:
+    - type: confirm_button
+      content: >
+        As a first step, you need to unlock the bootloader. A bootloader is the piece of software, that tells your phone
+        how to start and run an operating system (like Android). Your device should be turned on. This will reset your phone.
+    - type: link_button_with_confirm
+      content: >
+        - Create a Mi account on Xiaomi’s website. Beware that one account is only allowed to unlock one unique device every 30 days.
+
+        - Add a phone number to your Mi account, insert a SIM into your phone.
+
+        - Enable developer options in `Settings` > `About Phone` by repeatedly tapping MIUI Version.
+
+        - Link the device to your Mi account in `Settings` > `Additional settings` > `Developer options` > `Mi Unlock status`.
+
+        - Download the Mi Unlock app with the link bellow (Windows is required to run the app), and follow the instructions provided by the app. It may tell you that you have to wait, usually 7 days. If it does so, please wait the quoted amount of time before continuing to the next step!
+
+        - After device and Mi account are successfully verified, the bootloader should be unlocked.
+
+        - Since the device resets completely, you will need to re-enable USB debugging to continue : `Settings` > `Additional settings` > `Developer options` > `USB debugging`
+      link: https://en.miui.com/unlock/download_en.html
+  boot_recovery:
+    - type: confirm_button
+      content: >
+        Now you need to boot a custom recovery system on the phone. A recovery is a small subsystem on your phone, that manages updating,
+        adapting and repairing of the operating system.
+    - type: call_button
+      content: >
+        Once the device is fully booted, you need to reboot into the bootloader again by pressing 'Confirm and run' here. Then continue.
+      command: adb_reboot_bootloader
+    - type: call_button
+      content: >
+        Install the recovery you chosen before by pressing 'Confirm and run'. Once it's done continue.
+      command: fastboot_flash_recovery
+    - type: call_button
+      img: twrp-start.jpeg
+      content: >
+        Reboot to recovery by pressing 'Confirm and run', and hold the Vol+ button of your phone UNTIL you see the recovery.
+        If MiUI starts, you have to start the process again, since MiUI delete the recovery you just flashed.
+        Once it's done continue.
+      command: fastboot_reboot_recovery


### PR DESCRIPTION
This PR adds support for chime (Xiaomi Redmi Note 9 4G / Redmi 9T / Redmi 9 Power / POCO M3)
Asked in issue #519 

@Lesano : It's not tested for now, but it should work (same config as https://github.com/openandroidinstaller-dev/openandroidinstaller/pull/222 for instance)
Can you test it please? We can help you if needed.