### PR TITLE
Add support of Samsung Galaxy S5 plus

### DIFF
--- a/openandroidinstaller/assets/configs/kccat6.yaml
+++ b/openandroidinstaller/assets/configs/kccat6.yaml
@@ -1,0 +1,29 @@
+metadata:
+  maintainer: Ludovic Rousseau
+  device_name: Samsung Galaxy S5 plus
+  is_ab_device: false
+  device_code: kccat6
+  supported_device_codes:
+    - kccat6
+    - kccat6xx
+  twrp-link: kccat6
+steps:
+  unlock_bootloader:
+  boot_recovery:
+    - type: call_button
+      content: >
+        As a first step, you need to boot into the bootloader. A bootloader is the piece of software,
+        that tells your phone how to start and run an operating system (like Android). Your device should be turned on.
+        Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
+      command: adb_reboot_download
+    - type: call_button
+      content: >
+        In this step, you need to flash a custom recovery on your device.
+        Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      command: heimdall_flash_recovery
+    - type: confirm_button
+      img: samsung-buttons.png
+      content: >
+        Unplug the USB cable from your device. Then manually reboot into recovery by pressing the *Volume Down* + *Power buttons* for 8~10 seconds
+        until the screen turns black & release the buttons immediately when it does, then boot to recovery with the device powered off,
+        hold *Volume Up* + *Home* + *Power button*.


### PR DESCRIPTION
I got the eOS image e-0.15-p-20210310-UNOFFICIAL-kccat6.zip from https://community.e.foundation/t/unofficial-build-samsung-galaxy-s5-plus-kccat6/8308/16

and TWRP image from https://twrp.me/samsung/samsunggalaxys5plus.html

I am not sure if it is needed to have `kccat6xx` in `supported_device_codes:`
I have:
```
$ abd devices -l
List of devices attached
xxxxxxxx               device usb:1-2 product:kccat6xx model:SM_G901F device:kccat6 transport_id:4
```