### PR TITLE
Add support of Samsung Galaxy S III

### DIFF
--- a/openandroidinstaller/assets/configs/m0.yaml
+++ b/openandroidinstaller/assets/configs/m0.yaml
@@ -1,0 +1,28 @@
+metadata:
+  maintainer: Ludovic Rousseau
+  device_name: Samsung Galaxy S III
+  is_ab_device: false
+  device_code: m0
+  supported_device_codes:
+    - m0
+  twrp-link: m0
+steps:
+  unlock_bootloader:
+  boot_recovery:
+    - type: call_button
+      content: >
+        As a first step, you need to boot into the bootloader. A bootloader is the piece of software,
+        that tells your phone how to start and run an operating system (like Android). Your device should be turned on.
+        Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
+      command: adb_reboot_download
+    - type: call_button
+      content: >
+        In this step, you need to flash a custom recovery on your device.
+        Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      command: heimdall_flash_recovery
+    - type: confirm_button
+      img: samsung-buttons.png
+      content: >
+        Unplug the USB cable from your device. Then manually reboot into recovery by pressing the *Volume Down* + *Power buttons* for 8~10 seconds
+        until the screen turns black & release the buttons immediately when it does, then boot to recovery with the device powered off,
+        hold *Volume Up* + *Home* + *Power button*.

--- a/openandroidinstaller/assets/configs/m0.yaml
+++ b/openandroidinstaller/assets/configs/m0.yaml
@@ -1,0 +1,30 @@
+metadata:
+  maintainer: Ludovic Rousseau
+  device_name: Samsung Galaxy S III
+  is_ab_device: false
+  device_code: m0
+  supported_device_codes:
+    - m0
+    - i9300
+    - GT-I9300
+  twrp-link: m0
+steps:
+  unlock_bootloader:
+  boot_recovery:
+    - type: call_button
+      content: >
+        As a first step, you need to boot into the bootloader. A bootloader is the piece of software,
+        that tells your phone how to start and run an operating system (like Android). Your device should be turned on.
+        Then press 'Confirm and run' to reboot into the bootloader. Continue once it's done.
+      command: adb_reboot_download
+    - type: call_button
+      content: >
+        In this step, you need to flash a custom recovery on your device.
+        Press 'Confirm and run' to start the process. Confirm afterwards to continue.
+      command: heimdall_flash_recovery
+    - type: confirm_button
+      img: samsung-buttons.png
+      content: >
+        Unplug the USB cable from your device. Then manually reboot into recovery by pressing the *Volume Down* + *Power buttons* for 8~10 seconds
+        until the screen turns black & release the buttons immediately when it does, then boot to recovery with the device powered off,
+        hold *Volume Up* + *Home* + *Power button*.


### PR DESCRIPTION
I got the eOS image from https://community.e.foundation/t/unofficial-build-samsung-galaxy-s-iii-i9300-i9305-for-e-os-pie/60800 and the TWRP image from https://twrp.me/samsung/samsunggalaxys3internationalexynos.html

The image from twrp.me is named twrp-3.7.0_9-0-i9300.img but I had to rename it in twrp-3.7.0_9-0-m0.img to make OpenAndroidInstaller happy.

$ adb devices -l
List of devices attached
xxxxxxxxx       device usb:1-2 product:m0xx model:GT_I9300 device:m0 transport_id:2